### PR TITLE
Fix fatal error in post editing screen.

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -224,7 +224,7 @@ function admin_styles() {
  */
 function mce_css( $stylesheets ) {
 
-	function style_url() {
+	function editor_stylesheets() {
 
 		return TENUP_SCAFFOLD_URL . ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ?
 			"assets/css/frontend/editor-style.css" :
@@ -232,5 +232,5 @@ function mce_css( $stylesheets ) {
 
 	}
 
-	return $stylesheets . ',' . style_url();
+	return $stylesheets . ',' . editor_stylesheets();
 }


### PR DESCRIPTION
Fixes #13 & #22. 

```Fatal error: Cannot redeclare Facebook\Elearning\Plugin\Core\style_url() 
(previously declared in /srv/www/fbelearning/public_html/wp-content/plugins/fb-elearning/includes/functions/core.php:115) 
in /srv/www/fbelearning/public_html/wp-content/plugins/fb-elearning/includes/functions/core.php 
on line 261```

Internal method style_url() within mce_css filter threw a fatal error because of another method with the same name. Simple fix is to rename the method.